### PR TITLE
Transformable cell values and allow rich HTML values

### DIFF
--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -52,16 +52,19 @@
                     <tr
                         :key="item.id"
                         :class="classes['t-body-tr']"
-                        v-for="item in tableData.data"
+                        v-for="(item, rowIndex) in tableData.data"
                         @click="$emit('row-clicked', item)"
                         class="laravel-vue-datatable-tbody-tr">
                         <td 
                             :key="column.name"
                             :class="classes.td"
-                            v-for="column in columns"
+                            v-for="(column, columnIndex) in columns"
                             class="laravel-vue-datatable-td">
                             <laravel-vue-data-table-cell
+                                :row="rowIndex"
+                                :column="columnIndex"
                                 :value="item"
+                                :transform="column.transform"
                                 :name="column.name"
                                 :meta="column.meta"
                                 :event="column.event"

--- a/src/components/DataTableCell.vue
+++ b/src/components/DataTableCell.vue
@@ -70,7 +70,7 @@ export default {
             });
         }
         
-        if (this.transform) {
+        if (typeof this.transform === 'function') {
             return createElement('span', {domProps:{innerHTML: transformedValue}})
         }
 

--- a/src/components/DataTableCell.vue
+++ b/src/components/DataTableCell.vue
@@ -4,6 +4,15 @@ import ColumnNotFoundException from "../exceptions/ColumnNotFoundException";
 
 export default {
     props: {
+        row: {
+            type: Number,
+        },
+        column: {
+            type: Number,
+        },
+        transform: {
+
+        },
         comp: {
 
         },
@@ -36,13 +45,19 @@ export default {
         return {};
     },
     render(createElement) {
+        let transformedValue;
 
+        if (typeof this.transform === 'function') {
+           transformedValue = this.transform({ row: this.row, column: this.column, name: this.name, data: this.value, meta: this.meta });
+        }
+        
         if (this.comp) {
 
             let props = {
                 name: this.name,
                 data: this.value,
                 meta: this.meta,
+                transformed: transformedValue,
             };
 
             props[this.event] = this.handler;
@@ -53,6 +68,10 @@ export default {
                     classes: this.classes
                 },
             });
+        }
+        
+        if (this.transform) {
+            return createElement('span', {domProps:{innerHTML: transformedValue}})
         }
 
         let columnName;
@@ -71,7 +90,7 @@ export default {
             throw new ColumnNotFoundException(`The column ${this.name} was not found`);
         }
         
-        return createElement('span', {}, columnName);
+        return createElement('span', {domProps:{innerHTML: columnName}});
     }
 }
 </script>

--- a/src/components/DataTableTh.vue
+++ b/src/components/DataTableTh.vue
@@ -32,7 +32,7 @@
                 :style="{borderTop: column.orderable && column.name == currentSort && dir == 'desc' ? '5px solid #a3a3a3' : '5px solid #ccc' }">
             </div>
         </div>
-        {{ column.label }}
+        <span v-html="column.label"></span>
     </th>
 </template>
 


### PR DESCRIPTION
Add the ability to transform the displayed cell value by a transform callback.
Also allow HTML entities as values. So for example `10 &euro;` is rendered as `10 €` 

Usage of value transformation:

```js
columns: [
        {
          label: 'Subtotal',
          name: 'subtotal',
          columnName: 'total_base',
          orderable: true,
          transform: ({data, name}) => data[name] + ' &euro;',
        },
]
```