### PR TITLE
Global config & column classes

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,31 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Matches multiple files with brace expansion notation
+# Set default charset
+[*.{js,py}]
+charset = utf-8
+
+# 4 space indentation
+[*.js,*.vue ]
+indent_style = space
+indent_size = 4
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab
+
+# Indentation override for all JS under lib directory
+[lib/**.js]
+indent_style = space
+indent_size = 4
+
+# Matches the exact files either package.json or .travis.yml
+[{package.json,.travis.yml}]
+indent_style = space
+indent_size = 2

--- a/package.json
+++ b/package.json
@@ -74,7 +74,8 @@
     "vuex-persistedstate": "^2.5.4"
   },
   "files": [
-    "dist/*"
+    "dist/*",
+    "src/*"
   ],
   "eslintConfig": {
     "root": true,

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "axios": "^0.18.1",
     "laravel-vue-pagination": "^2.3.0",
     "lodash.debounce": "^4.0.8",
+    "lodash.defaultsdeep": "^4.6.1",
     "vue": "^2.6.10"
   },
   "devDependencies": {

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -385,7 +385,7 @@ export default {
         },
         translate: {
             type: Object,
-            default: () => (Object.assign({}, {
+            default: () => Object.assign({}, {
                 nextButton: 'Next',
                 previousButton: 'Previous',
                 placeholderSearch: 'Search Table',

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -364,20 +364,7 @@ export default {
         },
         classes: {
             type: Object,
-            default: () => ({
-                "table-container": {
-                    "table-responsive": true,
-                },
-                "table": {
-                    "table": true,
-                    "table-striped": true,
-                    "border": true,
-                },
-                "t-head": {},
-                "t-body": {},
-                "td": {},
-                "th": {},
-            }),
+            default: () => ({}),
         },
         headers: {
             type: Object,

--- a/src/components/DataTable.vue
+++ b/src/components/DataTable.vue
@@ -262,8 +262,8 @@ export default {
         },
         bodyCellClasses(column) {
             return this.mergeClasses(
-                typeof column.classes === "object" && column.classes["!override"] ? {} : this.computedClasses.td,
-                column.classes || {}, (column.classes || {}).td || {});
+                typeof column.columnClasses === "object" && column.columnClasses["!override"] ? {} : this.computedClasses.td,
+                column.columnClasses || {}, (column.columnClasses || {}).td || {});
         }
     },
     components: {

--- a/src/components/DataTableTh.vue
+++ b/src/components/DataTableTh.vue
@@ -37,7 +37,10 @@
 </template>
 
 <script>
+import MergeClasses from "../mixins/MergeClasses";
+
 export default {
+    mixins: [MergeClasses],
     data() {
         return {
             currentSort: '',
@@ -59,9 +62,12 @@ export default {
     },
     methods: {
         headerClasses(column) {
-            let classes = this.classes;
-            classes['table-header-sorting'] = column.orderable;
-            return classes;
+            return this.mergeClasses(
+                typeof column.classes === "object" && column.classes["!override"] ? {} : this.classes,
+                {"table-header-sorting": column.orderable},
+                column.classes || {}, 
+                (column.classes || {}).th || {}
+            );
         },
         sort(column) {
             this.setCurrentColumnSort(column.name);

--- a/src/components/DataTableTh.vue
+++ b/src/components/DataTableTh.vue
@@ -63,10 +63,10 @@ export default {
     methods: {
         headerClasses(column) {
             return this.mergeClasses(
-                typeof column.classes === "object" && column.classes["!override"] ? {} : this.classes,
+                typeof column.columnClasses === "object" && column.columnClasses["!override"] ? {} : this.classes,
                 {"table-header-sorting": column.orderable},
-                column.classes || {}, 
-                (column.classes || {}).th || {}
+                column.columnClasses || {}, 
+                (column.columnClasses || {}).th || {}
             );
         },
         sort(column) {

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -73,7 +73,7 @@ export default {
             return this.mergeClasses(
                 this.tableHeadClasses,
                 {"table-header-sorting": column.orderable},
-                (column.classes || {}).thead || {}
+                (column.columnClasses || {}).thead || {}
             );
         },
         sort(column) {

--- a/src/components/Table.vue
+++ b/src/components/Table.vue
@@ -27,8 +27,10 @@
 <script>
 
 import LaravelVueDataTableTh from './DataTableTh';
+import MergeClasses from "../mixins/MergeClasses";
 
 export default {
+    mixins: [MergeClasses],
     components: {
         LaravelVueDataTableTh
     },
@@ -68,9 +70,11 @@ export default {
     },
     methods: {
         headerClasses(column) {
-            let classes = this.tableHeadClasses;
-            classes['table-header-sorting'] = column.orderable;
-            return classes;
+            return this.mergeClasses(
+                this.tableHeadClasses,
+                {"table-header-sorting": column.orderable},
+                (column.classes || {}).thead || {}
+            );
         },
         sort(column) {
             this.$emit('sort', column.name, column.columnName);

--- a/src/mixins/MergeClasses.js
+++ b/src/mixins/MergeClasses.js
@@ -5,7 +5,7 @@ export default {
   
         for (let classlist in classlists) {
           if (classlists.hasOwnProperty(classlist)) {
-            let list = classlists[classlist];
+            let list = classlists[`${classlist}`];
   
             if (typeof list === "string") {
               classes.push(list);
@@ -15,8 +15,8 @@ export default {
               for (let cls in list) {
                 if (
                   list.hasOwnProperty(cls) &&
-                  typeof list[cls] !== "object" &&
-                  list[cls] &&
+                  typeof list[`${cls}`] !== "object" &&
+                  list[`${cls}`] &&
                   cls !== "!override"
                 ) {
                   classes.push(cls);

--- a/src/mixins/MergeClasses.js
+++ b/src/mixins/MergeClasses.js
@@ -17,7 +17,7 @@ export default {
                   typeof list[`${cls}`] !== "object" &&
                   list[`${cls}`] &&
                   cls !== "!override") {
-                  classes.push(cls);
+                  classes.push(`${cls}`);
                 }
               }
             }

--- a/src/mixins/MergeClasses.js
+++ b/src/mixins/MergeClasses.js
@@ -1,0 +1,32 @@
+export default {
+    methods: {
+      mergeClasses(...classlists) {
+        const classes = [];
+  
+        for (let classlist in classlists) {
+          if (classlists.hasOwnProperty(classlist)) {
+            let list = classlists[classlist];
+  
+            if (typeof list === "string") {
+              classes.push(list);
+            } else if (Array.isArray(list)) {
+              classes.push(...list);
+            } else if (typeof list === "object") {
+              for (let cls in list) {
+                if (
+                  list.hasOwnProperty(cls) &&
+                  typeof list[cls] !== "object" &&
+                  list[cls] &&
+                  cls !== "!override"
+                ) {
+                  classes.push(cls);
+                }
+              }
+            }
+          }
+        }
+  
+        return [...new Set(classes)].join(" ");
+      }
+    }
+  };

--- a/src/mixins/MergeClasses.js
+++ b/src/mixins/MergeClasses.js
@@ -13,12 +13,10 @@ export default {
               classes.push(...list);
             } else if (typeof list === "object") {
               for (let cls in list) {
-                if (
-                  list.hasOwnProperty(cls) &&
+                if (list.hasOwnProperty(cls) &&
                   typeof list[`${cls}`] !== "object" &&
                   list[`${cls}`] &&
-                  cls !== "!override"
-                ) {
+                  cls !== "!override") {
                   classes.push(cls);
                 }
               }


### PR DESCRIPTION
# Global configuration
When working in a project with multiple tables and if you want to keep your design consistent you would have to add a `classes` object to every single data table. Same happens with translations.

I think it's better to let the user define some global configuration. I have achieved this via `window.LaravelVueDatatable`
Also the classes object or any other global configuration should not completely replace the default object.

## An example of global configuration:
```js
window.LaravelVueDatatable = {
  // Spanish locales
  translate: {
    placeholderSearch: 'Filtrar',
    nextButton: 'Siguiente',
    previousButton: 'Anterior',
  },
  // Custom classes
  classes: {
    th: {
      'bg-info': true,
    },
    td: {
      'text-right': true,
    },
    table: {
      'table-striped': false,
      'table-borderless': true,
      'border': false,
    },
  },
}
```
All tables will inherit this global configuration.
If a datatable defines the classes property, those properties will override the global configuration so the user has full control over styling individual tables.

# Per column styles
Sometimes you need a certain column (and/or its header cell) to be aligned to the right/left/center or you want to apply other styling options to the column, for this to be possible I have enabled an optional property for the columns called `columnClasses`.

I have not used `classes` as it would be a breaking change with previous versions (but I would suggest renaming `classes` to `compClasses` to keep it consistent).

`columnClasses` can be:
- An array of classes `['p-5', 'text-right',]`
- A string `"p-5"` or even `"p-5 text-right"`
- An object. Details below.

### Example:

```js
columns: [
  {
    label: 'Article name',
    name: 'sku',
    columnClasses: 'text-right bg-success',
  },
  {
    label: 'Description',
    name: 'description',
    columnClasses: ['text-left', 'bg-success'],
  },
  {
    label: 'Price',
    name: 'price',
    columnClasses: {
        'text-right': true,           // <-- It will be applied both to the td and th cells
        'td': ['bg-danger'],          // <-- It will only be applied to the td cells
        'th': {'weight-bold': true},  // <-- It will only be applied to the th cells 
    },
  }
]
```

### Using `columnClasses` as an object
The object keys will be added as classes to the column if the value is not an array or an object and it evaluates to true.
The keys in the "root" of the object `columnClasses` that *are not* objects will be added to both the body & header cells of that particular column.

- `columnClasses.td` can define the styles (as an array/string/object) to be applied only to the body cells (td)
- `columnClasses.th` can define the styles (as an array/string/object) to be applied only to the header cells (th)

Column classes are **APPENDED** to the global classes and the table instance classes, if you want to **OVERRIDE** global & instance classes for a certain column you have to define the `columnClass` column property as an object and it must contains the following key-value pair `{"!override": true}` .

The following example is quite ugly but it serves as an example of the customization possibilities that it enables
![image](https://user-images.githubusercontent.com/71512870/94447364-f5cebe80-01a9-11eb-9fd2-55083ef8d5cb.png)

```js
columns: [
  {
    label: 'Price',
    name: 'price',
    columnClasses: {
        '!override': true,            // <-- the following columnClasses will override the global & instance classes  
        'text-right': true,           // <-- It will be applied both to the td and th cells
        'td': ['bg-danger'],          // <-- It will only be applied to the td cells
        'th': {'weight-bold': true},  // <-- It will only be applied to the th cells 
    },
  }
]
```

# HTML in th cells
Self explanatory. I have edited the code to allow HTML elements/entities as label. So you can add icons or HTML entities such as `&nbsp;` `&euro;` ...

```js
{
  label: '<i class="icon icon-tool-more"></i>',
  name: 'actions',
  ...
}
```

# Other changes
- package.json has been changed to add the new lodash.defaultsdeep dependency, and added `src/*` to the files, as a lot of us rather work/compile from the source

## Further suggestions
Maybe it would be a good idea to move the `markdown` `views` `__tests__` and other non essential files out of `/src` and really leave only the essential files that the user will need to compile the Vue DataTable.